### PR TITLE
FIXES #18: replace Object.assign with spread op

### DIFF
--- a/src/Dispatcher.js
+++ b/src/Dispatcher.js
@@ -36,7 +36,7 @@ export default class Dispatcher extends Component {
     let serverState = null;
     const state = reducePropsToState(
       helmetInstances.get().map(instance => {
-        const props = Object.assign({}, instance.props);
+        const props = {...instance.props};
         delete props.context;
         return props;
       })

--- a/src/utils.js
+++ b/src/utils.js
@@ -157,11 +157,10 @@ const getTagsFromPropsList = (tagName, primaryAttributes, propsList) => {
       const keys = Object.keys(instanceSeenTags);
       for (let i = 0; i < keys.length; i += 1) {
         const attributeKey = keys[i];
-        const tagUnion = Object.assign(
-          {},
-          approvedSeenTags[attributeKey],
-          instanceSeenTags[attributeKey]
-        );
+        const tagUnion = {
+          ...approvedSeenTags[attributeKey],
+          ...instanceSeenTags[attributeKey],
+        };
 
         approvedSeenTags[attributeKey] = tagUnion;
       }


### PR DESCRIPTION
I eliminated two occurrences of `Object.assign` by using the object spread syntax instead. The latter one is compiled away by babel.
See #18 for details.