### PR TITLE
Support Fragment within Helmet

### DIFF
--- a/__tests__/__snapshots__/fragment.test.js.snap
+++ b/__tests__/__snapshots__/fragment.test.js.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`misc parses Fragments 1`] = `"Hello"`;
+
+exports[`misc parses nested Fragments 1`] = `"Baz"`;

--- a/__tests__/fragment.test.js
+++ b/__tests__/fragment.test.js
@@ -1,0 +1,44 @@
+import React, { Fragment } from 'react';
+import ReactDOM from 'react-dom';
+import Helmet from '../src';
+import Provider from '../src/Provider';
+
+Helmet.defaultProps.defer = false;
+
+const mount = document.getElementById('mount');
+
+const render = node => {
+  ReactDOM.render(<Provider>{node}</Provider>, mount);
+};
+
+describe('fragments', () => {
+  it('parses Fragments', () => {
+    render(
+      <Helmet>
+        <Fragment>
+          <title>Hello</title>
+        </Fragment>
+      </Helmet>
+    );
+
+    expect(document.title).toMatchSnapshot();
+  });
+
+  it('parses nested Fragments', () => {
+    render(
+      <Helmet>
+        <Fragment>
+          <title>Foo</title>
+          <Fragment>
+            <title>Bar</title>
+            <Fragment>
+              <title>Baz</title>
+            </Fragment>
+          </Fragment>
+        </Fragment>
+      </Helmet>
+    );
+
+    expect(document.title).toMatchSnapshot();
+  });
+});

--- a/src/constants.js
+++ b/src/constants.js
@@ -28,6 +28,7 @@ export const TAG_NAMES = {
   SCRIPT: 'script',
   STYLE: 'style',
   TITLE: 'title',
+  FRAGMENT: 'Symbol(react.fragment)',
 };
 
 export const VALID_TAG_NAMES = Object.keys(TAG_NAMES).map(name => TAG_NAMES[name]);

--- a/src/index.js
+++ b/src/index.js
@@ -179,9 +179,18 @@ export default class Helmet extends Component {
         return obj;
       }, {});
 
-      this.warnOnInvalidChildren(child, nestedChildren);
+      let { type } = child;
+      if (typeof type === 'symbol') {
+        type = type.toString();
+      } else {
+        this.warnOnInvalidChildren(child, nestedChildren);
+      }
 
-      switch (child.type) {
+      switch (type) {
+        case TAG_NAMES.FRAGMENT:
+          newProps = this.mapChildrenToProps(nestedChildren, newProps);
+          break;
+
         case TAG_NAMES.LINK:
         case TAG_NAMES.META:
         case TAG_NAMES.NOSCRIPT:


### PR DESCRIPTION
Makes the following work:
```
<Helmet>
  <Fragment>
    <title>Foo</title>
    <Fragment>
      <title>Bar</title>
      <Fragment>
        <title>Baz</title>
      </Fragment>
    </Fragment>
  </Fragment>
</Helmet>
```

`<title>` will equal "Baz"

Fixes #20 