### PR TITLE
Move Context to Provider

### DIFF
--- a/src/Context.js
+++ b/src/Context.js
@@ -1,5 +1,0 @@
-import React from 'react';
-
-const defaultValue = {};
-
-export default React.createContext(defaultValue);

--- a/src/Provider.js
+++ b/src/Provider.js
@@ -1,9 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Context from './Context';
 import mapStateOnServer from './server';
 
 /* eslint-disable react/prop-types */
+
+const defaultValue = {};
+
+export const Context = React.createContext(defaultValue);
 
 export const providerShape = PropTypes.shape({
   setHelmet: PropTypes.func,

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import fastCompare from 'react-fast-compare';
 import invariant from 'invariant';
-import Context from './Context';
+import { Context } from './Provider';
 import Dispatcher from './Dispatcher';
 import { TAG_NAMES, VALID_TAG_NAMES, HTML_TAG_MAP } from './constants';
 


### PR DESCRIPTION
I have this special use case with two `react-helmet-async` installed in two projects. Let's say Project A and Project B.

And the `Context.js` module is causing an error:

```
: Uncaught TypeError: Cannot read property 'add' of undefined
```
The problem here is `Helmet` is importing `Context.js` from `react-helmet-async` in Project A. And `Provider` is importing `Context.js` from `react-helmet-async` in Project B. They're two different `Context`.

This pull request move `Context` into `Provider` module so `Helmet` shares the same context with `Provider` in my use case.