### PR TITLE
remove requestAnimationFrame

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -162,7 +162,7 @@ const handleStateChangeOnClient = newState => {
   }
 
   if (newState.defer) {
-    _helmetCallback = requestAnimationFrame(() => {
+    _helmetCallback = setTimeout(() => {
       commitTagChanges(newState, () => {
         _helmetCallback = null;
       });


### PR DESCRIPTION
is there a reason this depends on `requestAnimationFrame` at all? i'm using this for server rendering with phantomjs which doesn't have it, and it doesn't seem like this needs to use RAF when setTimeout would do the same thing?