### PR TITLE
fix: 🐛 typescript typings disable esModuleInterop enforcement

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 declare module 'react-helmet-async' {
-  import React from 'react';
+  import * as React from 'react';
   import Helmet, { HelmetData } from 'react-helmet';
   export { Helmet };
 


### PR DESCRIPTION
this config is not standard and forces people to use it in order to compile typescript projects