### PR TITLE
Support Nested Title Templates

### DIFF
--- a/__tests__/api/__snapshots__/title.test.js.snap
+++ b/__tests__/api/__snapshots__/title.test.js.snap
@@ -1,5 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`title API allows titleTemplate property to be nested 1`] = `"Page Name | Section Name | Site Name"`;
+
+exports[`title API allows titleTemplate property to be nested with a custom replace function 1`] = `"(1) Page Name | Section Name | Site Name"`;
+
 exports[`title API does not encode all characters with HTML character entity equivalents 1`] = `"膣膗 鍆錌雔"`;
 
 exports[`title API merges deepest component title with nearest upstream titleTemplate 1`] = `"This is a Second Test of the titleTemplate feature"`;

--- a/__tests__/api/title.test.js
+++ b/__tests__/api/title.test.js
@@ -111,6 +111,35 @@ describe('title', () => {
       expect(document.title).toMatchSnapshot();
     });
 
+    it('allows titleTemplate property to be nested', () => {
+      render(
+        <div>
+          <Helmet title="Test" titleTemplate="%s | Site Name" />
+          <Helmet titleTemplate={replace => replace(`%s | Section Name`)} />
+          <Helmet title="Page Name" />
+        </div>
+      );
+
+      expect(document.title).toMatchSnapshot();
+    });
+
+    it('allows titleTemplate property to be nested with a custom replace function', () => {
+      render(
+        <div>
+          <Helmet title="Test" titleTemplate="%s | Site Name" />
+          <Helmet titleTemplate={replace => replace(`%s | Section Name`)} />
+          <Helmet
+            titleTemplate={(replace, { titleTemplate, pattern }) =>
+              titleTemplate.replace(pattern, '(1) %s')
+            }
+          />
+          <Helmet title="Page Name" />
+        </div>
+      );
+
+      expect(document.title).toMatchSnapshot();
+    });
+
     it('does not encode all characters with HTML character entity equivalents', () => {
       const chineseTitle = '膣膗 鍆錌雔';
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -25,16 +25,16 @@ const getNestedProperty = (propsList, property) => {
     const props = propsList[i];
 
     if (Object.prototype.hasOwnProperty.call(props, property)) {
-      if (typeof props[property] === 'function') {
-        const parent = getNestedProperty(propsList.slice(0, i), property);
+      if (props[property] && typeof props[property] === 'function') {
+        const parent = getNestedProperty(propsList.slice(0, i), property) || '';
         return props[property](t => parent.replace(/%s/g, t), {
           [property]: parent,
+          pattern: /%s/g,
         });
       }
       return props[property];
     }
   }
-
   return null;
 };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -20,9 +20,27 @@ const getInnermostProperty = (propsList, property) => {
   return null;
 };
 
+const getNestedProperty = (propsList, property) => {
+  for (let i = propsList.length - 1; i >= 0; i -= 1) {
+    const props = propsList[i];
+
+    if (Object.prototype.hasOwnProperty.call(props, property)) {
+      if (typeof props[property] === 'function') {
+        const parent = getNestedProperty(propsList.slice(0, i), property);
+        return props[property](t => parent.replace(/%s/g, t), {
+          [property]: parent,
+        });
+      }
+      return props[property];
+    }
+  }
+
+  return null;
+};
+
 const getTitleFromPropsList = propsList => {
   let innermostTitle = getInnermostProperty(propsList, TAG_NAMES.TITLE);
-  const innermostTemplate = getInnermostProperty(propsList, HELMET_PROPS.TITLE_TEMPLATE);
+  const innermostTemplate = getNestedProperty(propsList, HELMET_PROPS.TITLE_TEMPLATE);
   if (Array.isArray(innermostTitle)) {
     innermostTitle = innermostTitle.join('');
   }


### PR DESCRIPTION
Add a `getNestedProperty` util that is used for titleTemplate, allowing it to be nested.

Fixes #96, relates to nfl/react-helmet#293

I have also opened a PR against react-helmet: https://github.com/nfl/react-helmet/pull/541