### PR TITLE
feat: allow React 17 in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
     "rimraf": "3.0.2"
   },
   "peerDependencies": {
-    "react": "^16.6.0",
-    "react-dom": "^16.6.0"
+    "react": "^16.6.0 || ^17.0.0-0",
+    "react-dom": "^16.6.0 || ^17.0.0-0"
   },
   "scripts": {
     "clean": "rimraf lib",


### PR DESCRIPTION
Closes #109

Contrary to #107, does NOT upgrade internal tests to React 17 yet - it just gets rid of the warning shown when react-helmet-async is used in React 17 environment.