### PR TITLE
Using multiple helmet <style> tags with SSR makes some style flickering 

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -50,3 +50,5 @@ export const HTML_TAG_MAP = Object.keys(REACT_TAG_MAP).reduce((obj, key) => {
 }, {});
 
 export const HELMET_ATTRIBUTE = 'data-rh';
+export const HELMET_SSR_ATTRIBUTE_VALUE = 'ssr';
+export const HELMET_DEFAULT_ATTRIBUTE_VALUE = 'true';

--- a/src/server.js
+++ b/src/server.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import {
   HELMET_ATTRIBUTE,
+  HELMET_SSR_ATTRIBUTE_VALUE,
+  HELMET_DEFAULT_ATTRIBUTE_VALUE,
   TAG_NAMES,
   REACT_TAG_MAP,
   TAG_PROPERTIES,
@@ -33,11 +35,11 @@ const generateTitleAsString = (type, title, attributes, encode) => {
   const attributeString = generateElementAttributesAsString(attributes);
   const flattenedTitle = flattenArray(title);
   return attributeString
-    ? `<${type} ${HELMET_ATTRIBUTE}="true" ${attributeString}>${encodeSpecialCharacters(
+    ? `<${type} ${HELMET_ATTRIBUTE}="${HELMET_DEFAULT_ATTRIBUTE_VALUE}" ${attributeString}>${encodeSpecialCharacters(
         flattenedTitle,
         encode
       )}</${type}>`
-    : `<${type} ${HELMET_ATTRIBUTE}="true">${encodeSpecialCharacters(
+    : `<${type} ${HELMET_ATTRIBUTE}="${HELMET_DEFAULT_ATTRIBUTE_VALUE}">${encodeSpecialCharacters(
         flattenedTitle,
         encode
       )}</${type}>`;
@@ -62,7 +64,7 @@ const generateTagsAsString = (type, tags, encode) =>
 
     const isSelfClosing = SELF_CLOSING_TAGS.indexOf(type) === -1;
 
-    return `${str}<${type} ${HELMET_ATTRIBUTE}="true" ${attributeHtml}${
+    return `${str}<${type} ${HELMET_ATTRIBUTE}="${HELMET_SSR_ATTRIBUTE_VALUE}" ${attributeHtml}${
       isSelfClosing ? `/>` : `>${tagContent}</${type}>`
     }`;
   }, '');
@@ -77,7 +79,7 @@ const generateTitleAsReactComponent = (type, title, attributes) => {
   // assigning into an array to define toString function on it
   const initProps = {
     key: title,
-    [HELMET_ATTRIBUTE]: true,
+    [HELMET_ATTRIBUTE]: HELMET_DEFAULT_ATTRIBUTE_VALUE,
   };
   const props = convertElementAttributesToReactProps(attributes, initProps);
 
@@ -88,7 +90,7 @@ const generateTagsAsReactComponent = (type, tags) =>
   tags.map((tag, i) => {
     const mappedTag = {
       key: i,
-      [HELMET_ATTRIBUTE]: true,
+      [HELMET_ATTRIBUTE]: HELMET_SSR_ATTRIBUTE_VALUE,
     };
 
     Object.keys(tag).forEach(attribute => {


### PR DESCRIPTION
I'm using `<Helmet><style>{ /* stylesheet */ }</style></Helmet>` in multiple descendant components and it works pretty fine on CSR. However when I'm doing SSR and later hydrating in the browser<sup>1</sup>, it throws some "style flickering" because of `<style>` regenerate.

Indeed what I see (with some breakpoints) is that the first equals `<style>` is kept (and not rewritten) but the `updateTags` function is removing the other "`oldTags`" (aka the tags with `HELMET_ATTRIBUTE` that are not yet rendered in the tree **but** already exist in `<head>`).

#### New behavior

To avoid this hydrate side-effect behavior I create this PR which defines an alternative value (previously `"true"`) for SSR rendering. Therefore the **"new flow"** (with this PR) is:

1. DOM is generated from SSR. The HTML looks like:

```html
<html>
    <head>
        <style data-rh="ssr">.stylesheet_component_A {}</style>
        <style data-rh="ssr">.stylesheet_component_B {}</style>
    </head>
    (...)
</html>
```

2. React hydrate and render **the (first) Component A**, the DOM looks like:

```html
<html>
    <head>
        <style data-rh="true">.stylesheet_component_A {}</style>
        <style data-rh="ssr">.stylesheet_component_B {}</style>
    </head>
    (...)
</html>
```


3. React hydrate and render **the next (child) Component B**, the DOM looks like:

```html
<html>
    <head>
        <style data-rh="true">.stylesheet_component_A {}</style>
        <style data-rh="true">.stylesheet_component_B {}</style>
    </head>
    (...)
</html>
```

#### Previous behavior


I want to make sure I'm crystal-clear so here is for comparison purpose **the current** buggy **behavior**.

1. DOM is generated from SSR. The HTML looks like:

```html
<html>
    <head>
        <style data-rh="true">.stylesheet_component_A {}</style>
        <style data-rh="true">.stylesheet_component_B {}</style>
    </head>
    (...)
</html>
```

2. React hydrate and render **the (first) Component A** (side-effect: the style for Component B is removed), the DOM looks like:

```html
<html>
    <head>
        <style data-rh="true">.stylesheet_component_A {}</style>
    </head>
    (...)
</html>
```

3. React hydrate and render **the next (child) Component B**, the DOM looks like:

```html
<html>
    <head>
        <style data-rh="true">.stylesheet_component_A {}</style>
        <style data-rh="true">.stylesheet_component_B {}</style>
    </head>
    (...)
</html>
```

---
<sup><sup>1</sup> Javascript bundle is loaded with async/defer attribute</sup>