### PR TITLE
Prioritizes certain tags for SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,54 @@ import { HelmetProvider } from 'react-helmet-async';
 HelmetProvider.canUseDOM = false;
 ```
 
+## Prioritizing tags for SEO
+
+It is understood that in some cases for SEO, certain tags should appear earlier in the HEAD. Using the `prioritizeSeoTags` flag on any `<Helmet>` component allows the server render of react-helmet-async to expose a method for prioritizing relevant SEO tags.
+
+In the component:
+```
+<Helmet prioritizeSeoTags>
+  <title>A fancy webpage</title>
+  <link rel="notImportant" href="https://www.chipotle.com" />
+  <meta name="whatever" value="notImportant" />
+  <link rel="canonical" href="https://www.tacobell.com" />
+  <meta property="og:title" content="A very important title"/>
+</Helmet>
+```
+
+In your server template:
+
+```
+<html>
+  <head>
+    ${helmet.title.toString()}
+    ${helmet.priority.toString()}
+    ${helmet.meta.toString()}
+    ${helmet.link.toString()}
+    ${helmet.script.toString()}
+  </head>
+  ...
+</html>
+```
+
+Will result in:
+
+```
+<html>
+  <head>
+    <title>A fancy webpage</title>
+    <meta property="og:title" content="A very important title"/>
+    <link rel="canonical" href="https://www.tacobell.com" />
+    <meta name="whatever" value="notImportant" />
+    <link rel="notImportant" href="https://www.chipotle.com" />
+  </head>
+  ...
+</html>
+```
+
+A list of prioritized tags and attributes can be found in [constants.js](./blob/master/src/constants.js).
+
+
 ## License
 
 Licensed under the Apache 2.0 License, Copyright © 2018 Scott Taylor

--- a/__tests__/server/server.test.js
+++ b/__tests__/server/server.test.js
@@ -100,6 +100,11 @@ describe('server', () => {
 
       expect(styleComponent).toEqual(isArray);
       expect(styleComponent).toHaveLength(0);
+
+      expect(head.priority).toBeDefined();
+      expect(head.priority.toString).toBeDefined();
+      expect(head.priority.toString()).toEqual('');
+      expect(head.priority.toComponent).toBeDefined();
     });
 
     it('does not render undefined attribute values', () => {
@@ -214,6 +219,11 @@ describe('server', () => {
 
       expect(styleComponent).toEqual(isArray);
       expect(styleComponent).toHaveLength(0);
+
+      expect(head.priority).toBeDefined();
+      expect(head.priority.toString).toBeDefined();
+      expect(head.priority.toString()).toEqual('');
+      expect(head.priority.toComponent).toBeDefined();
     });
 
     it('does not render undefined attribute values', () => {
@@ -228,6 +238,58 @@ describe('server', () => {
       const { script } = context.helmet;
 
       expect(script.toString()).toMatchSnapshot();
+    });
+
+    it('prioritizes SEO tags when asked to', () => {
+      const context = {};
+      render(
+        <Helmet prioritizeSeoTags>
+          <link rel="notImportant" href="https://www.chipotle.com" />
+          <link rel="canonical" href="https://www.tacobell.com" />
+          <meta property="og:title" content="A very important title" />
+        </Helmet>,
+        context
+      );
+
+      expect(context.helmet.priority.toString()).toContain(
+        'rel="canonical" href="https://www.tacobell.com"'
+      );
+      expect(context.helmet.link.toString()).not.toContain(
+        'rel="canonical" href="https://www.tacobell.com"'
+      );
+
+      expect(context.helmet.priority.toString()).toContain(
+        'property="og:title" content="A very important title"'
+      );
+      expect(context.helmet.meta.toString()).not.toContain(
+        'property="og:title" content="A very important title"'
+      );
+    });
+
+    it('does not prioritize SEO unless asked to', () => {
+      const context = {};
+      render(
+        <Helmet>
+          <link rel="notImportant" href="https://www.chipotle.com" />
+          <link rel="canonical" href="https://www.tacobell.com" />
+          <meta property="og:title" content="A very important title" />
+        </Helmet>,
+        context
+      );
+
+      expect(context.helmet.priority.toString()).not.toContain(
+        'rel="canonical" href="https://www.tacobell.com"'
+      );
+      expect(context.helmet.link.toString()).toContain(
+        'rel="canonical" href="https://www.tacobell.com"'
+      );
+
+      expect(context.helmet.priority.toString()).not.toContain(
+        'property="og:title" content="A very important title"'
+      );
+      expect(context.helmet.meta.toString()).toContain(
+        'property="og:title" content="A very important title"'
+      );
     });
   });
 });

--- a/src/constants.js
+++ b/src/constants.js
@@ -31,6 +31,30 @@ export const TAG_NAMES = {
   FRAGMENT: 'Symbol(react.fragment)',
 };
 
+export const SEO_PRIORITY_TAGS = {
+  link: { rel: ['amphtml', 'canonical', 'alternate'] },
+  script: { type: ['application/ld+json'] },
+  meta: {
+    charset: '',
+    name: ['robots', 'description'],
+    property: [
+      'og:type',
+      'og:title',
+      'og:url',
+      'og:image',
+      'og:image:alt',
+      'og:description',
+      'twitter:url',
+      'twitter:title',
+      'twitter:description',
+      'twitter:image',
+      'twitter:image:alt',
+      'twitter:card',
+      'twitter:site',
+    ],
+  },
+};
+
 export const VALID_TAG_NAMES = Object.keys(TAG_NAMES).map(name => TAG_NAMES[name]);
 
 export const REACT_TAG_MAP = {

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ export class Helmet extends Component {
    * @param {String} title: "Title"
    * @param {Object} titleAttributes: {"itemprop": "name"}
    * @param {String} titleTemplate: "MySite.com - %s"
+   * @param {Boolean} prioritizeSeoTags: false
    */
   /* eslint-disable react/forbid-prop-types, react/require-default-props */
   static propTypes = {
@@ -46,12 +47,14 @@ export class Helmet extends Component {
     title: PropTypes.string,
     titleAttributes: PropTypes.object,
     titleTemplate: PropTypes.string,
+    prioritizeSeoTags: PropTypes.bool,
   };
   /* eslint-enable react/prop-types, react/forbid-prop-types, react/require-default-props */
 
   static defaultProps = {
     defer: true,
     encodeSpecialCharacters: true,
+    prioritizeSeoTags: false,
   };
 
   static displayName = 'Helmet';

--- a/src/server.js
+++ b/src/server.js
@@ -177,7 +177,6 @@ const mapStateOnServer = props => {
     toComponent: () => {},
     toString: () => '',
   };
-  console.log('prioritizeSeoTags', prioritizeSeoTags);
   if (prioritizeSeoTags) {
     ({ priorityMethods, linkTags, metaTags, scriptTags } = getPriorityMethods(props));
   }

--- a/src/server.js
+++ b/src/server.js
@@ -175,8 +175,9 @@ const mapStateOnServer = props => {
   let { linkTags, metaTags, scriptTags } = props;
   let priorityMethods = {
     toComponent: () => {},
-    toString: () => {},
+    toString: () => '',
   };
+  console.log('prioritizeSeoTags', prioritizeSeoTags);
   if (prioritizeSeoTags) {
     ({ priorityMethods, linkTags, metaTags, scriptTags } = getPriorityMethods(props));
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -171,10 +171,17 @@ const getTagsFromPropsList = (tagName, primaryAttributes, propsList) => {
     .reverse();
 };
 
-const getAnyTrueFromPropsList = (propsList, checkedTag) =>
-  propsList.reduce((accumulator, currentPropList) =>
-    currentPropList[checkedTag] ? true : accumulator
-  );
+const getAnyTrueFromPropsList = (propsList, checkedTag) => {
+  if (Array.isArray(propsList) && propsList.length) {
+    for (let index = 0; index < propsList.length; index += 1) {
+      const prop = propsList[index];
+      if (prop[checkedTag]) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
 
 const reducePropsToState = propsList => ({
   baseTag: getBaseTagFromPropsList([TAG_PROPERTIES.HREF], propsList),
@@ -208,9 +215,7 @@ const reducePropsToState = propsList => ({
   styleTags: getTagsFromPropsList(TAG_NAMES.STYLE, [TAG_PROPERTIES.CSS_TEXT], propsList),
   title: getTitleFromPropsList(propsList),
   titleAttributes: getAttributesFromPropsList(ATTRIBUTE_NAMES.TITLE, propsList),
-  prioritizeSeoTags:
-    propsList.prioritizeSeoTags &&
-    getAnyTrueFromPropsList(propsList, HELMET_PROPS.PRIORITIZE_SEO_TAGS),
+  prioritizeSeoTags: getAnyTrueFromPropsList(propsList, HELMET_PROPS.PRIORITIZE_SEO_TAGS),
 });
 
 export const flattenArray = possibleArray =>

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,6 +6,7 @@ const HELMET_PROPS = {
   ENCODE_SPECIAL_CHARACTERS: 'encodeSpecialCharacters',
   ON_CHANGE_CLIENT_STATE: 'onChangeClientState',
   TITLE_TEMPLATE: 'titleTemplate',
+  PRIORITIZE_SEO_TAGS: 'prioritizeSeoTags',
 };
 
 const getInnermostProperty = (propsList, property) => {
@@ -19,6 +20,11 @@ const getInnermostProperty = (propsList, property) => {
 
   return null;
 };
+
+const getAnyTrueFromPropsList = (propsList, checkedTag) =>
+  propsList.reduce((accumulator, currentPropList) =>
+    currentPropList[checkedTag] ? true : accumulator
+  );
 
 const getTitleFromPropsList = propsList => {
   let innermostTitle = getInnermostProperty(propsList, TAG_NAMES.TITLE);
@@ -170,39 +176,76 @@ const getTagsFromPropsList = (tagName, primaryAttributes, propsList) => {
     .reverse();
 };
 
-const reducePropsToState = propsList => ({
-  baseTag: getBaseTagFromPropsList([TAG_PROPERTIES.HREF], propsList),
-  bodyAttributes: getAttributesFromPropsList(ATTRIBUTE_NAMES.BODY, propsList),
-  defer: getInnermostProperty(propsList, HELMET_PROPS.DEFER),
-  encode: getInnermostProperty(propsList, HELMET_PROPS.ENCODE_SPECIAL_CHARACTERS),
-  htmlAttributes: getAttributesFromPropsList(ATTRIBUTE_NAMES.HTML, propsList),
-  linkTags: getTagsFromPropsList(
-    TAG_NAMES.LINK,
-    [TAG_PROPERTIES.REL, TAG_PROPERTIES.HREF],
-    propsList
-  ),
-  metaTags: getTagsFromPropsList(
-    TAG_NAMES.META,
-    [
-      TAG_PROPERTIES.NAME,
-      TAG_PROPERTIES.CHARSET,
-      TAG_PROPERTIES.HTTPEQUIV,
-      TAG_PROPERTIES.PROPERTY,
-      TAG_PROPERTIES.ITEM_PROP,
-    ],
-    propsList
-  ),
-  noscriptTags: getTagsFromPropsList(TAG_NAMES.NOSCRIPT, [TAG_PROPERTIES.INNER_HTML], propsList),
-  onChangeClientState: getOnChangeClientState(propsList),
-  scriptTags: getTagsFromPropsList(
-    TAG_NAMES.SCRIPT,
-    [TAG_PROPERTIES.SRC, TAG_PROPERTIES.INNER_HTML],
-    propsList
-  ),
-  styleTags: getTagsFromPropsList(TAG_NAMES.STYLE, [TAG_PROPERTIES.CSS_TEXT], propsList),
-  title: getTitleFromPropsList(propsList),
-  titleAttributes: getAttributesFromPropsList(ATTRIBUTE_NAMES.TITLE, propsList),
-});
+// helper to inspect for matching props on components
+export const checkIfPropsMatch = (props, toMatch) => {
+  const pairs = Object.entries(props);
+  for (let i = 0; i < pairs.length; i += 1) {
+    const [propName, propVal] = pairs[i];
+    if (toMatch[propName]) {
+      // e.g. if rel exists in the list of allowed props
+      const propWeAreCheckingOut = toMatch[propName]; // e.g. [amphtml, alternate, etc]
+      if (propWeAreCheckingOut.includes(propVal)) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+
+// re-usable fn to prioritize tags by matching props
+export const prioritizer = (elementsList, propsToMatch) => {
+  if (Array.isArray(elementsList)) {
+    return elementsList.reduce(
+      (acc, elementAttrs) => {
+        if (checkIfPropsMatch(elementAttrs, propsToMatch)) {
+          acc.priority.push(elementAttrs);
+        } else {
+          acc.default.push(elementAttrs);
+        }
+        return acc;
+      },
+      { priority: [], default: [] }
+    );
+  }
+  return { default: elementsList };
+};
+
+const reducePropsToState = propsList => {
+  return {
+    baseTag: getBaseTagFromPropsList([TAG_PROPERTIES.HREF], propsList),
+    bodyAttributes: getAttributesFromPropsList(ATTRIBUTE_NAMES.BODY, propsList),
+    defer: getInnermostProperty(propsList, HELMET_PROPS.DEFER),
+    encode: getInnermostProperty(propsList, HELMET_PROPS.ENCODE_SPECIAL_CHARACTERS),
+    htmlAttributes: getAttributesFromPropsList(ATTRIBUTE_NAMES.HTML, propsList),
+    linkTags: getTagsFromPropsList(
+      TAG_NAMES.LINK,
+      [TAG_PROPERTIES.REL, TAG_PROPERTIES.HREF],
+      propsList
+    ),
+    metaTags: getTagsFromPropsList(
+      TAG_NAMES.META,
+      [
+        TAG_PROPERTIES.NAME,
+        TAG_PROPERTIES.CHARSET,
+        TAG_PROPERTIES.HTTPEQUIV,
+        TAG_PROPERTIES.PROPERTY,
+        TAG_PROPERTIES.ITEM_PROP,
+      ],
+      propsList
+    ),
+    noscriptTags: getTagsFromPropsList(TAG_NAMES.NOSCRIPT, [TAG_PROPERTIES.INNER_HTML], propsList),
+    onChangeClientState: getOnChangeClientState(propsList),
+    scriptTags: getTagsFromPropsList(
+      TAG_NAMES.SCRIPT,
+      [TAG_PROPERTIES.SRC, TAG_PROPERTIES.INNER_HTML],
+      propsList
+    ),
+    styleTags: getTagsFromPropsList(TAG_NAMES.STYLE, [TAG_PROPERTIES.CSS_TEXT], propsList),
+    title: getTitleFromPropsList(propsList),
+    titleAttributes: getAttributesFromPropsList(ATTRIBUTE_NAMES.TITLE, propsList),
+    prioritizeSeoTags: getAnyTrueFromPropsList(propsList, HELMET_PROPS.PRIORITIZE_SEO_TAGS),
+  };
+};
 
 export const flattenArray = possibleArray =>
   Array.isArray(possibleArray) ? possibleArray.join('') : possibleArray;


### PR DESCRIPTION
Addresses #23, allowing for prioritization of certain HTML tags towards the begining of the `<head>`. This only runs on the server, but is respected on the client. 

See see [this section of the README](https://github.com/staylor/react-helmet-async/blob/dd030ab1b288abb5d1f1ac8ae120d2aec24bf766/README.md#prioritizing-tags-for-seo) for full details. 

