### PR TITLE
docs: fix link to seo constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Will result in:
 </html>
 ```
 
-A list of prioritized tags and attributes can be found in [constants.js](./blob/master/src/constants.js).
+A list of prioritized tags and attributes can be found in [constants.js](./src/constants.js).
 
 
 ## License


### PR DESCRIPTION
Currently, points to https://github.com/staylor/react-helmet-async/blob/master/blob/master/src/constants.js