### PR TITLE
Singleton instances

### DIFF
--- a/__tests__/server/helmetData.test.js
+++ b/__tests__/server/helmetData.test.js
@@ -76,14 +76,13 @@ describe('Helmet Data', () => {
 
     it('works with the same context object but separate HelmetData instances', () => {
       const context = {};
-      const instances = [];
 
       render(
         <div>
-          <Helmet helmetData={new HelmetData(context, instances)}>
+          <Helmet helmetData={new HelmetData(context)}>
             <base href="http://mysite.com" />
           </Helmet>
-          <Helmet helmetData={new HelmetData(context, instances)}>
+          <Helmet helmetData={new HelmetData(context)}>
             <base href="http://mysite.com/public" />
           </Helmet>
         </div>

--- a/index.d.ts
+++ b/index.d.ts
@@ -81,7 +81,7 @@ declare module 'react-helmet-async' {
   }
 
   export class HelmetData {
-    constructor(context: any, instances?: Array<any>)
+    constructor(context: any)
   }
 
   export class HelmetProvider extends React.Component<ProviderProps> {

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -2,6 +2,7 @@ import 'raf/polyfill';
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import ReactDOM from 'react-dom';
+import { clearInstances } from './src/HelmetData';
 
 configure({ adapter: new Adapter() });
 
@@ -40,4 +41,5 @@ beforeEach(() => {
 
 afterEach(() => {
   ReactDOM.unmountComponentAtNode(mount);
+  clearInstances();
 });

--- a/src/HelmetData.js
+++ b/src/HelmetData.js
@@ -1,30 +1,30 @@
 import mapStateOnServer from './server';
 
-export default class HelmetData {
-  instances = [];
+const instances = [];
 
+export function clearInstances() {
+  instances.length = 0;
+}
+
+export default class HelmetData {
   value = {
     setHelmet: serverState => {
       this.context.helmet = serverState;
     },
     helmetInstances: {
-      get: () => this.instances,
+      get: () => instances,
       add: instance => {
-        this.instances.push(instance);
+        instances.push(instance);
       },
       remove: instance => {
-        const index = this.instances.indexOf(instance);
-        this.instances.splice(index, 1);
+        const index = instances.indexOf(instance);
+        instances.splice(index, 1);
       },
     },
   };
 
-  constructor(context, instances) {
+  constructor(context) {
     this.context = context;
-
-    if (instances) {
-      this.instances = instances;
-    }
 
     if (!HelmetData.canUseDOM) {
       context.helmet = mapStateOnServer({

--- a/src/HelmetData.js
+++ b/src/HelmetData.js
@@ -7,26 +7,29 @@ export function clearInstances() {
 }
 
 export default class HelmetData {
+  instances = [];
+
   value = {
     setHelmet: serverState => {
       this.context.helmet = serverState;
     },
     helmetInstances: {
-      get: () => instances,
+      get: () => (this.canUseDOM ? instances : this.instances),
       add: instance => {
-        instances.push(instance);
+        (this.canUseDOM ? instances : this.instances).push(instance);
       },
       remove: instance => {
-        const index = instances.indexOf(instance);
-        instances.splice(index, 1);
+        const index = (this.canUseDOM ? instances : this.instances).indexOf(instance);
+        (this.canUseDOM ? instances : this.instances).splice(index, 1);
       },
     },
   };
 
-  constructor(context) {
+  constructor(context, canUseDOM = typeof document !== 'undefined') {
     this.context = context;
+    this.canUseDOM = canUseDOM;
 
-    if (!HelmetData.canUseDOM) {
+    if (!canUseDOM) {
       context.helmet = mapStateOnServer({
         baseTag: [],
         bodyAttributes: {},

--- a/src/Provider.js
+++ b/src/Provider.js
@@ -36,7 +36,7 @@ export default class Provider extends Component {
   constructor(props) {
     super(props);
 
-    this.helmetData = new HelmetData(this.props.context);
+    this.helmetData = new HelmetData(this.props.context, Provider.canUseDOM);
   }
 
   render() {

--- a/src/index.js
+++ b/src/index.js
@@ -5,13 +5,13 @@ import invariant from 'invariant';
 import { Context } from './Provider';
 import HelmetData from './HelmetData';
 import Dispatcher from './Dispatcher';
+import { without } from './utils';
 import { TAG_NAMES, VALID_TAG_NAMES, HTML_TAG_MAP } from './constants';
 
 export { default as HelmetData } from './HelmetData';
 export { default as HelmetProvider } from './Provider';
 
 /* eslint-disable class-methods-use-this */
-
 export class Helmet extends Component {
   /**
    * @param {Object} base: {"target": "_blank", "href": "http://mysite.com/"}
@@ -63,7 +63,7 @@ export class Helmet extends Component {
   static displayName = 'Helmet';
 
   shouldComponentUpdate(nextProps) {
-    return !fastCompare(this.props, nextProps);
+    return !fastCompare(without(this.props, 'helmetData'), without(nextProps, 'helmetData'));
   }
 
   mapNestedChildrenToProps(child, nestedChildren) {
@@ -235,7 +235,7 @@ export class Helmet extends Component {
 
     return helmetData ? (
       // eslint-disable-next-line react/jsx-props-no-spreading
-      <Dispatcher {...newProps} context={helmetData.value} />
+      <Dispatcher {...newProps} context={helmetData.value} helmetData={undefined} />
     ) : (
       <Context.Consumer>
         {(

--- a/src/utils.js
+++ b/src/utils.js
@@ -250,3 +250,10 @@ export const prioritizer = (elementsList, propsToMatch) => {
   }
   return { default: elementsList };
 };
+
+export const without = (obj, key) => {
+  return {
+    ...obj,
+    [key]: undefined,
+  };
+};


### PR DESCRIPTION
1. fix: move to a singleton for tracking `Helmet` instances 

This resolves an issue where multiple `HelmetProvider`s on the same
page don't know about each other.

2. fix: don't emit changes when the `helmetData` wrapper object changes 

This makes the context free environment behave like a context environment,
for example, the outer context could be destroyed and recreated, and emitting
changes isn't effected. `The helmetData` should behave the same.