### PR TITLE
rename HelmetData interface to HelmetServerState

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -44,7 +44,7 @@ declare module 'react-helmet-async' {
   export class Helmet extends React.Component<HelmetProps> {
   }
   
-  export interface HelmetData {
+  export interface HelmetServerState {
     base: HelmetDatum;
     bodyAttributes: HelmetHTMLBodyDatum;
     htmlAttributes: HelmetHTMLElementDatum;
@@ -73,7 +73,7 @@ declare module 'react-helmet-async' {
   }
 
   export interface FilledContext {
-    helmet: HelmetData;
+    helmet: HelmetServerState;
   }
 
   interface ProviderProps {
@@ -82,6 +82,9 @@ declare module 'react-helmet-async' {
 
   export class HelmetData {
     constructor(context: any)
+    context: {
+      helmet: HelmetServerState
+    }
   }
 
   export class HelmetProvider extends React.Component<ProviderProps> {


### PR DESCRIPTION
In the TypeScript file, because there is `class HelmetData` and `interface HelmetData` and the name are exactly the same.
This means we are unable to import the type for `class HelmetData`. 
For example `import type {HelmetData} from 'react-helmet-async'` gives the interface type, not the class type). See it happening [here](https://github.com/Shopify/hydrogen/pull/596/files#diff-622e580245bf2de41f2923da321ac61875c9b37618d09d54c1916b0cb0e97209) and how we need to create new type to get around it.

This PR rename the interface type to make this less confusing.