### PR TITLE
fix(types): Add explicit children props to support React18 typedef

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -41,7 +41,7 @@ declare module 'react-helmet-async' {
     titleTemplate?: string;
   }
 
-  export class Helmet extends React.Component<HelmetProps> {
+  export class Helmet extends React.Component<React.PropsWithChildren<HelmetProps>> {
   }
   
   export interface HelmetServerState {
@@ -87,7 +87,7 @@ declare module 'react-helmet-async' {
     }
   }
 
-  export class HelmetProvider extends React.Component<ProviderProps> {
+  export class HelmetProvider extends React.Component<React.PropsWithChildren<ProviderProps>> {
     static canUseDOM: boolean;
   }
 }


### PR DESCRIPTION
Add explicit children props to support React18 typedef changes:

>Due to changes in the React18 typedefs https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210
We plan to remove implicit children from @types/react. 

Closes #166 