### PR TITLE
fix: Datum.toComponent() should return ReactElement instead of Component

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -59,7 +59,7 @@ declare module 'react-helmet-async' {
 
   export interface HelmetDatum {
     toString(): string;
-    toComponent(): React.Component<any>;
+    toComponent(): React.ReactElement[];
   }
 
   export interface HelmetHTMLBodyDatum {


### PR DESCRIPTION
`React.Component` is something like `function Comp() {...}` or `class Comp extends Component`, while `React.ReactElement` is like `<Comp />`, the "return value" of a component. This has blocked me from doing something like `React.Children.toArray(datum)`.