### PR TITLE
Add children type to Helmet and HelmetProvider

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -41,6 +41,7 @@ declare module 'react-helmet-async' {
     titleAttributes?: Object;
     titleTemplate?: string;
     prioritizeSeoTags?: boolean;
+    children: React.ReactNode;
   }
 
   export class Helmet extends React.Component<React.PropsWithChildren<HelmetProps>> {}
@@ -79,6 +80,7 @@ declare module 'react-helmet-async' {
   }
 
   interface ProviderProps {
+    children: React.ReactNode;
     context?: {};
   }
 


### PR DESCRIPTION
With the new React 18, explicitly defining your children has become mandatory. Children is not assumed automagically anymore. Simple fix - would appreciate this update.