### PR TITLE
feat: add "generator" as SEO priority meta

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -36,7 +36,7 @@ export const SEO_PRIORITY_TAGS = {
   script: { type: ['application/ld+json'] },
   meta: {
     charset: '',
-    name: ['robots', 'description'],
+    name: ['generator', 'robots', 'description'],
     property: [
       'og:type',
       'og:title',


### PR DESCRIPTION

https://html.spec.whatwg.org/multipage/semantics.html#standard-metadata-names

```
<meta name="generator" content="Docusaurus v2.0.0-rc.1">
```

This Meta tag doesn't need to be at the very top, but most frameworks implement it this way. 

It is very convenient to use DevTools and see which generator was used at the very top, it helps us know which tool a site is using without inspecting a long list of metadata

<img width="694" alt="CleanShot 2022-08-19 at 13 21 17@2x" src="https://user-images.githubusercontent.com/749374/185607967-5472cb49-951f-4e7c-868f-d366c1aab5db.png">

<img width="727" alt="CleanShot 2022-08-19 at 13 23 05@2x" src="https://user-images.githubusercontent.com/749374/185608064-757b8a05-0eb1-410f-9f92-285289bfb513.png">

<img width="622" alt="CleanShot 2022-08-19 at 13 23 13@2x" src="https://user-images.githubusercontent.com/749374/185608086-113635a7-543c-4950-b9d9-4dee56792973.png">

<img width="623" alt="CleanShot 2022-08-19 at 13 23 35@2x" src="https://user-images.githubusercontent.com/749374/185608138-ef67cc2e-9e15-421a-bc90-98b123c73d49.png">

cc @justinph


