### PR TITLE
Prioritizing tags for SEO by default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ export class Helmet extends Component {
   static defaultProps = {
     defer: true,
     encodeSpecialCharacters: true,
-    prioritizeSeoTags: false,
+    prioritizeSeoTags: true,
   };
 
   static displayName = 'Helmet';


### PR DESCRIPTION
I was wondering if we can make this flag **true** by default when using the package. Can solve issues for newcomers to SEO, just like me, that we are not aware of actually