### PR TITLE
Log when the context does not exist instead of throwing errors

### DIFF
--- a/src/Dispatcher.js
+++ b/src/Dispatcher.js
@@ -19,11 +19,27 @@ export default class Dispatcher extends Component {
   }
 
   componentDidUpdate() {
+    if (!this.props.context.helmetInstances) {
+      // eslint-disable-next-line no-console
+      console.trace(
+        'No helmet context was found, make sure to wrap your app in a HelmetProvider'
+      );
+      return;
+    }
+
     this.emitChange();
   }
 
   componentWillUnmount() {
     const { helmetInstances } = this.props.context;
+    if (!helmetInstances) {
+      // eslint-disable-next-line no-console
+      console.trace(
+        'No helmet context was found, make sure to wrap your app in a HelmetProvider'
+      );
+      return;
+    }
+
     helmetInstances.remove(this);
     this.emitChange();
   }
@@ -57,6 +73,14 @@ export default class Dispatcher extends Component {
     this.rendered = true;
 
     const { helmetInstances } = this.props.context;
+    if (!helmetInstances) {
+      // eslint-disable-next-line no-console
+      console.trace(
+        'No helmet context was found, make sure to wrap your app in a HelmetProvider'
+      );
+      return;
+    }
+
     helmetInstances.add(this);
     this.emitChange();
   }


### PR DESCRIPTION
We were switching from `react-helmet` to `react-helmet-async`, but our production application threw errors at runtime (effectively shutting our website down) because of a misplaced `<Helmet>` tag outside of the `<HelmetProvider>`. This caused `react-helmet-async` to throw the error `Cannot read properties of undefined (reading 'add')`.

While that's an obvious problem that can be addressed separately, it would help users who are switching to check for a missing context beforehand and not attempt to reference objects that are possibly `undefined`. This change checks to see if `helmetInstances` is truthy and, if not, logs a trace to the console and returns immediately. This way, users can be aware of their code not behaving correctly while still maintaining a running website.