### PR TITLE
events in scripts as reference and not render it as string

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,4 @@
-import { HELMET_ATTRIBUTE, TAG_NAMES, TAG_PROPERTIES } from './constants';
+import { HELMET_ATTRIBUTE, TAG_EVENTS, TAG_NAMES, TAG_PROPERTIES } from './constants';
 import type { Attributes, StateUpdate, TagList } from './types';
 import { flattenArray } from './utils';
 
@@ -36,6 +36,14 @@ const updateTags = (type: string, tags: HTMLElement[]) => {
               // @ts-ignore
               newElement.appendChild(document.createTextNode(tag.cssText));
             }
+          } else if (
+            (TAG_EVENTS.ON_LOAD === attribute || TAG_EVENTS.ON_ERROR === attribute) &&
+            typeof tag[attribute] === 'function' &&
+            newElement instanceof HTMLScriptElement
+          ) {
+            const attr = attribute as keyof HTMLElement;
+            const value = typeof tag[attr] === 'undefined' ? '' : tag[attr];
+            newElement[attribute] = value as any;
           } else {
             const attr = attribute as keyof HTMLElement;
             const value = typeof tag[attr] === 'undefined' ? '' : tag[attr];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,6 +17,11 @@ export enum ATTRIBUTE_NAMES {
   TITLE = 'titleAttributes',
 }
 
+export enum TAG_EVENTS {
+  ON_LOAD = 'onload',
+  ON_ERROR = 'onerror',
+}
+
 export enum TAG_NAMES {
   BASE = 'base',
   BODY = 'body',


### PR DESCRIPTION
based on https://github.com/staylor/react-helmet-async/issues/202 one of the issues seems to be that we are trying to set onload as string using setAttribute and based on https://developer.mozilla.org/en-US/docs/Web/API/Element/setAttribute#value will save it as string making this can lose the context in some cases or triggering the wrong references

this probably is not perfect but if require any change, let me know