### PR TITLE
Added correct props type to provider constructor

### DIFF
--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -19,7 +19,7 @@ export default class HelmetProvider extends Component<PropsWithChildren<Provider
 
   helmetData: HelmetData;
 
-  constructor(props: ProviderProps) {
+  constructor(props: PropsWithChildren<ProviderProps>) {
     super(props);
 
     this.helmetData = new HelmetData(this.props.context || {}, HelmetProvider.canUseDOM);


### PR DESCRIPTION
When passing the provider as a type to a function it's currently not compatible with `ComponentType<{ children: ReactNode }>` as the props in the constructor is not accepting `children` when the component does. The prop types in the constructor should be the same as the component itself.