### PR TITLE
Update Dispatcher.tsx

### DIFF
--- a/src/Dispatcher.tsx
+++ b/src/Dispatcher.tsx
@@ -27,6 +27,10 @@ export default class HelmetDispatcher extends Component<DispatcherProps> {
     return !shallowEqual(nextProps, this.props);
   }
 
+  componentDidUpdate() {
+    this.emitChange();
+  }
+
   emitChange() {
     const { helmetInstances, setHelmet } = this.props.context;
     let serverState = null;

--- a/src/Dispatcher.tsx
+++ b/src/Dispatcher.tsx
@@ -27,16 +27,6 @@ export default class HelmetDispatcher extends Component<DispatcherProps> {
     return !shallowEqual(nextProps, this.props);
   }
 
-  componentDidUpdate() {
-    this.emitChange();
-  }
-
-  componentWillUnmount() {
-    const { helmetInstances } = this.props.context;
-    helmetInstances.remove(this);
-    this.emitChange();
-  }
-
   emitChange() {
     const { helmetInstances, setHelmet } = this.props.context;
     let serverState = null;


### PR DESCRIPTION
removes deprecated react hooks in favor of the class `init`.

Addresses issues with NextJS and avoids warning as mentioned in issue #213 