### PR TITLE
fix: remove react-dom from peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
     "vitest": "0.34.6"
   },
   "peerDependencies": {
-    "react": "^16.6.0 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^16.6.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.6.0 || ^17.0.0 || ^18.0.0"
   },
   "scripts": {
     "clean": "rimraf lib",


### PR DESCRIPTION
react-dom is not strictly required by this library - it's not used in the source code directly, only in tests (which is covered by the dev dependency). We use react-helmet-async in expo-router (which works on any or all of iOS, Android, and web), and this peer dependency led to the following issue with the release of react@18.3.0 / react-dom@18.3.0: https://github.com/expo/expo/issues/28471#issuecomment-2080094893