### PR TITLE
fix(types): import JSX type from react

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import type { PropsWithChildren, ReactElement, ReactNode } from 'react';
+import type { JSX, PropsWithChildren, ReactElement, ReactNode } from 'react';
 import React, { Component } from 'react';
 import fastCompare from 'react-fast-compare';
 import invariant from 'invariant';


### PR DESCRIPTION
The global type is removed in React 19 in favor of importing it.